### PR TITLE
isJsonString should implicitly assert value is of string type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This extension specifies types of values passed to:
 * `Assertion::notNull`
 * `Assertion::same`
 * `Assertion::notSame`
+* `Assertion::isJsonString`
 * `nullOr*` and `all*` variants of the above methods
 
 `Assert::that`, `Assert::thatNullOr` and `Assert::thatAll` chaining methods are also supported.

--- a/src/Type/BeberleiAssert/AssertHelper.php
+++ b/src/Type/BeberleiAssert/AssertHelper.php
@@ -222,37 +222,37 @@ class AssertHelper
 	{
 		if (self::$resolvers === null) {
 			self::$resolvers = [
-				'integer' => function (Scope $scope, Arg $value): ?\PhpParser\Node\Expr {
+				'integer' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_int'),
 						[$value]
 					);
 				},
-				'string' => function (Scope $scope, Arg $value): ?\PhpParser\Node\Expr {
+				'string' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_string'),
 						[$value]
 					);
 				},
-				'float' => function (Scope $scope, Arg $value): ?\PhpParser\Node\Expr {
+				'float' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_float'),
 						[$value]
 					);
 				},
-				'numeric' => function (Scope $scope, Arg $value): ?\PhpParser\Node\Expr {
+				'numeric' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_numeric'),
 						[$value]
 					);
 				},
-				'boolean' => function (Scope $scope, Arg $value): ?\PhpParser\Node\Expr {
+				'boolean' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_bool'),
 						[$value]
 					);
 				},
-				'scalar' => function (Scope $scope, Arg $value): ?\PhpParser\Node\Expr {
+				'scalar' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_scalar'),
 						[$value]
@@ -269,19 +269,19 @@ class AssertHelper
 						[$value]
 					);
 				},
-				'isResource' => function (Scope $scope, Arg $value): ?\PhpParser\Node\Expr {
+				'isResource' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_resource'),
 						[$value]
 					);
 				},
-				'isCallable' => function (Scope $scope, Arg $value): ?\PhpParser\Node\Expr {
+				'isCallable' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_callable'),
 						[$value]
 					);
 				},
-				'isArray' => function (Scope $scope, Arg $value): ?\PhpParser\Node\Expr {
+				'isArray' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_array'),
 						[$value]
@@ -311,43 +311,43 @@ class AssertHelper
 						)
 					);
 				},
-				'true' => function (Scope $scope, Arg $expr): ?\PhpParser\Node\Expr {
+				'true' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\BinaryOp\Identical(
 						$expr->value,
 						new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('true'))
 					);
 				},
-				'false' => function (Scope $scope, Arg $expr): ?\PhpParser\Node\Expr {
+				'false' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\BinaryOp\Identical(
 						$expr->value,
 						new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('false'))
 					);
 				},
-				'null' => function (Scope $scope, Arg $expr): ?\PhpParser\Node\Expr {
+				'null' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\BinaryOp\Identical(
 						$expr->value,
 						new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('null'))
 					);
 				},
-				'notNull' => function (Scope $scope, Arg $expr): ?\PhpParser\Node\Expr {
+				'notNull' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\BinaryOp\NotIdentical(
 						$expr->value,
 						new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('null'))
 					);
 				},
-				'same' => function (Scope $scope, Arg $value1, Arg $value2): ?\PhpParser\Node\Expr {
+				'same' => function (Scope $scope, Arg $value1, Arg $value2): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\BinaryOp\Identical(
 						$value1->value,
 						$value2->value
 					);
 				},
-				'notSame' => function (Scope $scope, Arg $value1, Arg $value2): ?\PhpParser\Node\Expr {
+				'notSame' => function (Scope $scope, Arg $value1, Arg $value2): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\BinaryOp\NotIdentical(
 						$value1->value,
 						$value2->value
 					);
 				},
-				'subclassOf' => function (Scope $scope, Arg $expr, Arg $class): ?\PhpParser\Node\Expr {
+				'subclassOf' => function (Scope $scope, Arg $expr, Arg $class): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_subclass_of'),
 						[

--- a/src/Type/BeberleiAssert/AssertHelper.php
+++ b/src/Type/BeberleiAssert/AssertHelper.php
@@ -356,6 +356,12 @@ class AssertHelper
 						]
 					);
 				},
+				'isJsonString' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
+					return new \PhpParser\Node\Expr\FuncCall(
+						new \PhpParser\Node\Name('is_string'),
+						[$value]
+					);
+				},
 			];
 		}
 

--- a/tests/Type/BeberleiAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/BeberleiAssert/AssertTypeSpecifyingExtensionTest.php
@@ -182,64 +182,68 @@ class AssertTypeSpecifyingExtensionTest extends \PHPStan\Testing\RuleTestCase
 				110,
 			],
 			[
-				'Variable $that is: Assert\AssertionChain<int|null>',
-				116,
+				'Variable $ac is: string',
+				113,
 			],
 			[
-				'Variable $thatOrNull is: Assert\AssertionChain<int|null>',
+				'Variable $that is: Assert\AssertionChain<int|null>',
 				119,
 			],
 			[
-				'Variable $a is: int',
-				120,
+				'Variable $thatOrNull is: Assert\AssertionChain<int|null>',
+				122,
 			],
 			[
-				'Variable $assertNullOr is: Assert\AssertionChain<mixed>-nullOr',
+				'Variable $a is: int',
 				123,
 			],
 			[
-				'Variable $b is: string|null',
-				125,
+				'Variable $assertNullOr is: Assert\AssertionChain<mixed>-nullOr',
+				126,
 			],
 			[
-				'Variable $assertNullOr2 is: Assert\AssertionChain<mixed>-nullOr',
+				'Variable $b is: string|null',
 				128,
 			],
 			[
-				'Variable $c is: string|null',
-				130,
+				'Variable $assertNullOr2 is: Assert\AssertionChain<mixed>-nullOr',
+				131,
 			],
 			[
-				'Variable $assertAll is: Assert\AssertionChain<array>-all',
+				'Variable $c is: string|null',
 				133,
 			],
 			[
-				'Variable $d is: array<string>',
-				135,
+				'Variable $assertAll is: Assert\AssertionChain<array>-all',
+				136,
 			],
 			[
-				'Variable $assertAll2 is: Assert\AssertionChain<iterable>-all',
+				'Variable $d is: array<string>',
 				138,
 			],
 			[
+				'Variable $assertAll2 is: Assert\AssertionChain<iterable>-all',
+				141,
+			],
+			[
 				'Variable $e is: iterable<string>',
-				140,
+				143,
 			],
 			[
 				'Variable $f is: array<string>',
-				145,
-			],
-			[
-				'Variable $assertThatFunction is: Assert\AssertionChain<mixed>',
 				148,
 			],
 			[
-				'Variable $assertThatNullOrFunction is: Assert\AssertionChain<mixed>-nullOr',
+				'Variable $assertThatFunction is: Assert\AssertionChain<mixed>',
 				151,
 			],
 			[
-				'Variable $assertThatAllFunction is: Assert\AssertionChain<mixed>-all',
+				'Variable $assertThatNullOrFunction is: Assert\AssertionChain<mixed>-nullOr',
 				154,
+			],
+			[
+				'Variable $assertThatAllFunction is: Assert\AssertionChain<mixed>-all',
+				157,
 			],
 		]);
 	}

--- a/tests/Type/BeberleiAssert/data/data.php
+++ b/tests/Type/BeberleiAssert/data/data.php
@@ -7,7 +7,7 @@ use Assert\{Assert, Assertion};
 class Foo
 {
 
-	public function doFoo($a, $b, array $c, iterable $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, string $n, $p, $r, $s, ?int $t, ?int $u, $x, $aa, array $ab)
+	public function doFoo($a, $b, array $c, iterable $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, string $n, $p, $r, $s, ?int $t, ?int $u, $x, $aa, array $ab, ?string $ac)
 	{
 		$a;
 
@@ -108,6 +108,9 @@ class Foo
 
 		Assertion::allSubclassOf($ab, self::class);
 		$ab;
+
+		Assertion::isJsonString($ac);
+		$ac;
 	}
 
 	public function doBar(?int $a, $b, $c, array $d, iterable $e, $g)


### PR DESCRIPTION
When this assert passes, it's clear the value is string. IMO should be stripped of eg. null