### PR TITLE
Add support for `integerish` assertions

### DIFF
--- a/src/Type/BeberleiAssert/AssertHelper.php
+++ b/src/Type/BeberleiAssert/AssertHelper.php
@@ -366,6 +366,12 @@ class AssertHelper
 						[$value]
 					);
 				},
+				'integerish' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
+					return new \PhpParser\Node\Expr\FuncCall(
+						new \PhpParser\Node\Name('is_numeric'),
+						[$value]
+					);
+				},
 			];
 		}
 

--- a/tests/Type/BeberleiAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/BeberleiAssert/AssertTypeSpecifyingExtensionTest.php
@@ -252,6 +252,10 @@ class AssertTypeSpecifyingExtensionTest extends \PHPStan\Testing\RuleTestCase
 				'Variable $a is: array<stdClass>',
 				167,
 			],
+			[
+				'Variable $a is: float|int|(string&numeric)',
+				173,
+			],
 		]);
 	}
 

--- a/tests/Type/BeberleiAssert/data/data.php
+++ b/tests/Type/BeberleiAssert/data/data.php
@@ -167,6 +167,11 @@ class Foo
 		$a;
 	}
 
+	public function doFooBar($a): void
+	{
+		Assertion::integerish($a);
+		$a;
+	}
 }
 
 class Bar


### PR DESCRIPTION
Fixes #18 

type-wise, this should be identical as the `is_numeric` function call