### PR TITLE
Fix allSubclassOf test case

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	],
 	"require": {
 		"php": "^7.1 || ^8.0",
-		"phpstan/phpstan": "^1.0"
+		"phpstan/phpstan": "^1.4.7"
 	},
 	"require-dev": {
 		"beberlei/assert": "^3.3.0",

--- a/tests/Type/BeberleiAssert/data/data.php
+++ b/tests/Type/BeberleiAssert/data/data.php
@@ -107,7 +107,7 @@ class Foo
 		\PHPStan\Testing\assertType('class-string<PHPStan\Type\BeberleiAssert\Foo>|PHPStan\Type\BeberleiAssert\Foo', $aa);
 
 		Assertion::allSubclassOf($ab, self::class);
-		\PHPStan\Testing\assertType('array<*NEVER*>', $ab); // // should be array<PHPStan\Type\BeberleiAssert\Foo>
+		\PHPStan\Testing\assertType('array<class-string<PHPStan\Type\BeberleiAssert\Foo>|PHPStan\Type\BeberleiAssert\Foo>', $ab);
 
 		Assertion::isJsonString($ac);
 		\PHPStan\Testing\assertType('string', $ac);


### PR DESCRIPTION
Apparently this has been fixed in https://github.com/phpstan/phpstan-src/commit/73f14dbf82cf054f9ef7f57ffe3a2794e0e659e9 / https://github.com/phpstan/phpstan-src/pull/1039