### PR TITLE
Support `Assertion::allNotBlank()` and `thatAll($value)->notBlank()`

### DIFF
--- a/src/Type/BeberleiAssert/AssertHelper.php
+++ b/src/Type/BeberleiAssert/AssertHelper.php
@@ -22,14 +22,19 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
 use ReflectionObject;
 use function array_key_exists;
 use function count;
@@ -164,6 +169,25 @@ class AssertHelper
 				$args[0]->value,
 				static function (Type $type) use ($valueType): Type {
 					return TypeCombinator::remove($type, $valueType);
+				}
+			);
+		}
+
+		if ($assertName === 'notBlank') {
+			return self::allArrayOrIterable(
+				$typeSpecifier,
+				$scope,
+				$args[0]->value,
+				static function (Type $type): Type {
+					return TypeCombinator::remove(
+						$type,
+						new UnionType([
+							new NullType(),
+							new ConstantBooleanType(false),
+							new ConstantStringType(''),
+							new ConstantArrayType([], []),
+						])
+					);
 				}
 			);
 		}

--- a/src/Type/BeberleiAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/BeberleiAssert/AssertTypeSpecifyingExtension.php
@@ -42,6 +42,7 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 				'allNotIsInstanceOf' => 2,
 				'allNotNull' => 1,
 				'allNotSame' => 2,
+				'allNotBlank' => 1,
 			];
 			return array_key_exists($staticMethodReflection->getName(), $methods)
 				&& count($node->getArgs()) >= $methods[$staticMethodReflection->getName()];

--- a/tests/Type/BeberleiAssert/data/data.php
+++ b/tests/Type/BeberleiAssert/data/data.php
@@ -147,6 +147,11 @@ class Foo
 
 		Assertion::notBlank($ag);
 		\PHPStan\Testing\assertType('non-empty-array', $ag);
+
+		/** @var (string|null|bool|array)[] $notBlankValues */
+		$notBlankValues = doFoo();
+		Assertion::allNotBlank($notBlankValues);
+		\PHPStan\Testing\assertType('array<non-empty-array|non-empty-string|true>', $notBlankValues);
 	}
 
 	public function doBar(?int $a, $b, $c, array $d, iterable $e, $g)
@@ -182,6 +187,11 @@ class Foo
 		$f = doFoo();
 		Assert::thatAll($f)->notNull();
 		\PHPStan\Testing\assertType('array<string>', $f);
+
+		/** @var (string|null|bool|array)[] $notBlankValues */
+		$notBlankValues = doFoo();
+		Assert::thatAll($notBlankValues)->notBlank();
+		\PHPStan\Testing\assertType('array<non-empty-array|non-empty-string|true>', $notBlankValues);
 
 		$assertThatFunction = \Assert\that($g);
 		\PHPStan\Testing\assertType('Assert\AssertionChain<mixed>', $assertThatFunction);


### PR DESCRIPTION
Although the README declares that all `all*` variants are supported, #58 did not introduce support for `Assertion::allNotBlank($value)`. Moreover, calling `Assert::thatAll($value)->notBlank()` chaining method resulted in an internal error (due to throwing a `ShouldNotHappenException`). This PR fixes these two issues.