### PR TITLE
Fix `Call to method Assert\AssertionChain::isJsonString() will always evaluate to true.`

### DIFF
--- a/tests/Type/BeberleiAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/BeberleiAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -30,6 +30,16 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				16,
 				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
+			[
+				'Call to method Assert\AssertionChain::isJsonString() will always evaluate to true.',
+				22,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+			[
+				'Call to method Assert\AssertionChain::isJsonString() will always evaluate to true.',
+				25,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
 		]);
 	}
 

--- a/tests/Type/BeberleiAssert/ImpossibleCheckTypeStaticMethodCallRuleTest.php
+++ b/tests/Type/BeberleiAssert/ImpossibleCheckTypeStaticMethodCallRuleTest.php
@@ -23,6 +23,7 @@ class ImpossibleCheckTypeStaticMethodCallRuleTest extends RuleTestCase
 			[
 				'Call to static method Assert\Assertion::string() with string will always evaluate to true.',
 				12,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 			[
 				'Call to static method Assert\Assertion::allString() with array<string> will always evaluate to true.',

--- a/tests/Type/BeberleiAssert/data/data.php
+++ b/tests/Type/BeberleiAssert/data/data.php
@@ -129,7 +129,7 @@ class Foo
 		\PHPStan\Testing\assertType('array<class-string<PHPStan\Type\BeberleiAssert\Foo>|PHPStan\Type\BeberleiAssert\Foo>', $ab);
 
 		Assertion::isJsonString($ac);
-		\PHPStan\Testing\assertType('string', $ac);
+		\PHPStan\Testing\assertType('non-empty-string', $ac);
 
 		/** @var array{a?: string, b?: int} $ad */
 		$ad = doFoo();

--- a/tests/Type/BeberleiAssert/data/impossible-check.php
+++ b/tests/Type/BeberleiAssert/data/impossible-check.php
@@ -16,4 +16,12 @@ class Bar
 		Assert::that($strings)->all()->string();
 	}
 
+	public function nonEmptyStringAndSomethingUnknownNarrow(string $a, array $b): void
+	{
+		Assert::that($a)->isJsonString();
+		Assert::that($a)->isJsonString(); // only this should report
+
+		Assert::thatAll($b)->isJsonString();
+		Assert::thatAll($b)->isJsonString(); // only this should report
+	}
 }


### PR DESCRIPTION
Fixes this:
```php
function assertJson(string $value): void
{
  Assert::that($value)->isJsonString(); // Call to method Assert\AssertionChain::isJsonString() will always evaluate to true.
}
```

Also narrows type to `non-empty-string`, because the assertion fails if empty string is provided.

I based this implementation on https://github.com/phpstan/phpstan-webmozart-assert/pull/143