### PR TITLE
Support remaining `*Exists` assertions

### DIFF
--- a/src/Type/BeberleiAssert/AssertHelper.php
+++ b/src/Type/BeberleiAssert/AssertHelper.php
@@ -397,6 +397,10 @@ class AssertHelper
 					new Name('property_exists'),
 					[$object, $property],
 				),
+				'methodExists' => static fn (Scope $scope, Arg $object, Arg $property): Expr => new FuncCall(
+					new Name('method_exists'),
+					[$object, $property],
+				),
 				'notBlank' => static fn (Scope $scope, Arg $value): Expr => new BooleanAnd(
 					new BooleanAnd(
 						new NotIdentical(

--- a/src/Type/BeberleiAssert/AssertHelper.php
+++ b/src/Type/BeberleiAssert/AssertHelper.php
@@ -393,6 +393,10 @@ class AssertHelper
 						[$key, $array],
 					),
 				),
+				'propertyExists' => static fn (Scope $scope, Arg $object, Arg $property): Expr => new FuncCall(
+					new Name('property_exists'),
+					[$object, $property],
+				),
 				'notBlank' => static fn (Scope $scope, Arg $value): Expr => new BooleanAnd(
 					new BooleanAnd(
 						new NotIdentical(

--- a/src/Type/BeberleiAssert/AssertHelper.php
+++ b/src/Type/BeberleiAssert/AssertHelper.php
@@ -401,6 +401,14 @@ class AssertHelper
 					new Name('method_exists'),
 					[$object, $property],
 				),
+				'classExists' => static fn (Scope $scope, Arg $value): Expr => new FuncCall(
+					new Name('class_exists'),
+					[$value],
+				),
+				'interfaceExists' => static fn (Scope $scope, Arg $value): Expr => new FuncCall(
+					new Name('interface_exists'),
+					[$value],
+				),
 				'notBlank' => static fn (Scope $scope, Arg $value): Expr => new BooleanAnd(
 					new BooleanAnd(
 						new NotIdentical(

--- a/src/Type/BeberleiAssert/AssertHelper.php
+++ b/src/Type/BeberleiAssert/AssertHelper.php
@@ -397,9 +397,9 @@ class AssertHelper
 					new Name('property_exists'),
 					[$object, $property],
 				),
-				'methodExists' => static fn (Scope $scope, Arg $object, Arg $property): Expr => new FuncCall(
+				'methodExists' => static fn (Scope $scope, Arg $object, Arg $method): Expr => new FuncCall(
 					new Name('method_exists'),
-					[$object, $property],
+					[$object, $method],
 				),
 				'classExists' => static fn (Scope $scope, Arg $value): Expr => new FuncCall(
 					new Name('class_exists'),

--- a/tests/Type/BeberleiAssert/data/data.php
+++ b/tests/Type/BeberleiAssert/data/data.php
@@ -47,6 +47,16 @@ class Foo
 		Assertion::methodExists($j, 'doBar');
 		\PHPStan\Testing\assertType('object&hasMethod(doBar)&hasProperty(foo)', $j);
 
+		/** @var string $classString */
+		$classString = doFoo();
+		Assertion::classExists($classString);
+		\PHPStan\Testing\assertType('class-string', $classString);
+
+		/** @var string $interfaceString */
+		$interfaceString = doFoo();
+		Assertion::interfaceExists($interfaceString);
+		\PHPStan\Testing\assertType('class-string', $interfaceString);
+
 		Assertion::isResource($k);
 		\PHPStan\Testing\assertType('resource', $k);
 

--- a/tests/Type/BeberleiAssert/data/data.php
+++ b/tests/Type/BeberleiAssert/data/data.php
@@ -44,6 +44,9 @@ class Foo
 		Assertion::propertyExists($j, 'foo');
 		\PHPStan\Testing\assertType('object&hasProperty(foo)', $j);
 
+		Assertion::methodExists($j, 'doBar');
+		\PHPStan\Testing\assertType('object&hasMethod(doBar)&hasProperty(foo)', $j);
+
 		Assertion::isResource($k);
 		\PHPStan\Testing\assertType('resource', $k);
 

--- a/tests/Type/BeberleiAssert/data/data.php
+++ b/tests/Type/BeberleiAssert/data/data.php
@@ -41,6 +41,9 @@ class Foo
 		Assertion::objectOrClass($j);
 		\PHPStan\Testing\assertType('object', $j);
 
+		Assertion::propertyExists($j, 'foo');
+		\PHPStan\Testing\assertType('object&hasProperty(foo)', $j);
+
 		Assertion::isResource($k);
 		\PHPStan\Testing\assertType('resource', $k);
 


### PR DESCRIPTION
Adds support for:
* `Assertion::propertyExists`
* `Assertion::methodExists`
* `Assertion::classExists`
* `Assertion::interfaceExists`